### PR TITLE
Fixed errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need to do the same for the English and Italian synset databases:
 ```
 To make full use of the semantic data that is included in the MultiWordNet, you will also want to compile the list of common relations and semfield hierarchy:
 ```
->>> compile('common', 'relations', 'semfield', 'semfield_hierarchy')
+>>> compile('common', 'relation', 'semfield', 'semfield_hierarchy')
 ```
 
 ### Basic usage

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ To make full use of the semantic data that is included in the MultiWordNet, you 
 ...
 
 >>> synset = LWN.get_synset('n#07462736')  # you can find a synset directly, if you know its offset ID
->>> synset.lemmas
+>>> synset.words
 ...
 ```

--- a/latinwordnet/db/italian/italian_synset.sql
+++ b/latinwordnet/db/italian/italian_synset.sql
@@ -6273,7 +6273,7 @@ INSERT INTO italian_synset VALUES ('n#06675773',' antiparticella ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#N0000073',' antipastiera ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#05637439',' antipasto hors-d''_oeuvre ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#05576323',' antipatia ',NULL,NULL);
-INSERT INTO italian_synset VALUES ('n#05577305',' antipatia avversione contrarietà disgusto fobia idiosincrasia renitenza repugnanza ripugnanza ',NULL,'"provare contrarietà nei confronti di"');
+INSERT INTO italian_synset VALUES ('n#05577305',' antipatia avversione contrarietà disgusto fobia idiosincrasia renitenza repugnanza ripugnanza ',NULL,'"provare contrarietà nei confronti di"');
 INSERT INTO italian_synset VALUES ('r#00215884',' antipaticamente sgradevolmente spiacevolmente ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#06956899',' antipatico ',NULL,'un apersona che non è simpatca');
 INSERT INTO italian_synset VALUES ('n#07453274',' attaccabottoni empiastro gonfiatore impiastro importuno martellatore noia ossessione peste piaga piattola rogna rompicazzo rompicoglioni rompimento rompiscatole rompitasche rottorio scocciatore seccatore vescicante ',NULL,'"sei un gran rompimento"');
@@ -35648,7 +35648,7 @@ INSERT INTO italian_synset VALUES ('n#04036899',' libertà_civile ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#04037453',' libertà_di_stampa ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#04037215',' libertà_di_religione ',NULL,'libertà di professare la propria religione');
 INSERT INTO italian_synset VALUES ('n#04037335',' libertà_di_parola libertà_di_espressione ',NULL,'libertà di esprimere le proprie opinioni');
-INSERT INTO italian_synset VALUES ('n#04037574',' libertà_di_riunione ',NULL,'diritto di riunirsi liberamente, senza necessità di autorizzazione preventiva, per qualsiasi motivo (politico, sindacale, religioso, culturale), purché la riunione avvenga pacificamente e senza luso di armi');
+INSERT INTO italian_synset VALUES ('n#04037574',' libertà_di_riunione ',NULL,'diritto di riunirsi liberamente, senza necessità di autorizzazione preventiva, per qualsiasi motivo (politico, sindacale, religioso, culturale), purché la riunione avvenga pacificamente e senza luso di armi');
 INSERT INTO italian_synset VALUES ('n#04038033',' diritto_a_un_giusto_processo diritto_al_giusto_processo ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('n#04035825',' diritto_alla_libertà ',NULL,NULL);
 INSERT INTO italian_synset VALUES ('a#01840657',' senza_meta senza_direzione alla_deriva ',NULL,'"un viaggio senza meta"; "movimento caotico e disordinato, senza direzione"; "nave alla deriva"');


### PR DESCRIPTION
Ciao Will, 
I forked your library (great tool, thanks!) and came across a few errors. This pull-request contains the corrections.

1. The compiling of `italian_synset.sql` was returning the errors you see below:  
```
>>> compile('italian', 'synset')
italian_synset.sql:  16%|██▌             | 6167/38750 [00:04<00:21, 1541.12it/s]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/greta/GitHub/lwn-py/latinwordnet/db/__init__.py", line 42, in compile
    db.executescript(sql)
sqlite3.OperationalError: unrecognized token: "'"provare contrarietà nei confronti di"
>>> compile('italian', 'synset')
italian_synset.sql:  92%|█████████████▊ | 35545/38749 [00:23<00:02, 1464.21it/s]Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/greta/GitHub/lwn-py/latinwordnet/db/__init__.py", line 42, in compile
    db.executescript(sql)
sqlite3.OperationalError: unrecognized token: "'diritto di riunirsi liberamente, senza necessità di autorizzazione preventiva, per qualsiasi motivo (politico, sindacale, religioso, culturale"
```

It was just a little dirt. I cleaned and tested and it works fine now. 

2. Two typos in your `README` file here:

`>>> compile('common', 'relations', 'semfield', 'semfield_hierarchy')`

It's not *relations* but *relation*. Fixed and it compiles file now.

And here:

`>>> synset.lemmas`

The attribute is not `lemmas` but `words`. 